### PR TITLE
fix: automatic creation 'config.php' file and added automatic creation of 'phinx.yml' file with autofilling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV COMPOSER_ALLOW_SUPERUSER=1 \
     MYSQL_USER=user \
     MYSQL_PASSWORD=123456 \
     MYSQL_DATABASE=rename \
-    CONFIG_FILE=/var/www/html/config/config.php
+    CONFIG_FILE=/var/www/html/config/config.php \
+    PHINX_CONFIG_FILE=/var/www/html/phinx.yml
 
 RUN apt-get -y update && \
     apt-get install -y \
@@ -31,6 +32,12 @@ sed -i \"s/'server' => 'localhost'/'server' => '\${MYSQL_HOSTNAME}'/\" \${CONFIG
 sed -i \"s/'username' => 'root'/'username' => '\${MYSQL_USER}'/\" \${CONFIG_FILE} \n\
 sed -i \"s/'password' => '123456'/'password' => '\${MYSQL_PASSWORD}'/\" \${CONFIG_FILE} \n\
 sed -i \"s/'database_name' => 'rename'/'database_name' => '\${MYSQL_DATABASE}'/\" \${CONFIG_FILE} \n\
+\
+set -e \n\
+cp \${PHINX_CONFIG_FILE}.example \${PHINX_CONFIG_FILE} \n\
+sed -i \"s/name:/name: \${MYSQL_DATABASE}/\" \${PHINX_CONFIG_FILE} \n\
+sed -i \"s/user:/user: \${MYSQL_USER}/\" \${PHINX_CONFIG_FILE} \n\
+sed -i \"s/pass: ''/pass: '\${MYSQL_PASSWORD}'/\" \${PHINX_CONFIG_FILE} \n\
 " > /container-configurator.sh
 
 RUN chmod +x /container-configurator.sh


### PR DESCRIPTION
I tried to split RUN command for two separate commands for auto creation and auto filling 'config.php' and 'phinx.yml' files, it doesn't work. So I combined them in on general RUN command -- it works fine.